### PR TITLE
Remove unused variables

### DIFF
--- a/src/ingest.py
+++ b/src/ingest.py
@@ -146,9 +146,7 @@ async def ingest_weekly() -> pd.DataFrame:
         logger.warning("DATABASE_URL not set; skipping DB upsert")
     else:
         conn = psycopg2.connect(database_url)
-        values = [tuple(row.iloc[0])]
         columns = ",".join(SCHEMA_COLUMNS)
-        placeholders = ",".join([f"%({c})s" for c in SCHEMA_COLUMNS])
         update = ",".join([f"{c} = EXCLUDED.{c}" for c in SCHEMA_COLUMNS[1:]])
         with conn, conn.cursor() as cur:
             psycopg2.extras.execute_values(


### PR DESCRIPTION
## Summary
- remove unused `values` and `placeholders` assignments in `ingest_weekly`
- keep tests green

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd8af73308331aa3ee93f34b55886