### PR TITLE
Refactor test imports

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,12 +1,9 @@
-from pathlib import Path
-import sys
-sys.path.insert(0,str(Path(__file__).resolve().parents[1]))
 from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
 
-import src.ingest as ingest
+from src import ingest
 
 
 def test_coin_gecko_to_weekly():


### PR DESCRIPTION
## Summary
- add `tests/__init__.py` to make tests importable as a package
- remove manual `sys.path` manipulation from `tests/test_ingest.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd8bd02c08331bf83fead61cbcba3