### PR TITLE
Fix FRED fetch error handling

### DIFF
--- a/src/ingest.py
+++ b/src/ingest.py
@@ -115,7 +115,8 @@ async def _fetch_fred_series(client: httpx.AsyncClient, series_id: str) -> pd.Da
         resp.raise_for_status()
     except httpx.HTTPStatusError:
         logger.warning("Failed to fetch FRED series %s", series_id)
-        return pd.DataFrame(columns=[column_name])
+        empty_index = pd.DatetimeIndex([], tz="UTC")
+        return pd.DataFrame(columns=[column_name], index=empty_index)
     df = pd.read_csv(io.StringIO(resp.text))
     df.columns = [c.lower() for c in df.columns]
     # Rename the first column to "date" since FRED uses "observation_date"


### PR DESCRIPTION
## Summary
- return empty datetime-indexed DataFrame when FRED fetch fails
- test ingest_weekly when FRED series cannot be fetched
- ensure index type check in existing FRED error test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bee6af09c83319c3463b482018c1e