### PR TITLE
Add Stooq fallback for gold price

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@ export FRED_API_KEY="your_fred_key"
 ```
 
 When a requested series cannot be retrieved (for example if the key is missing or the API returns an error), the script continues and the affected column will be filled with `NA` values.
+
+If the gold price series (`GOLDAMGBD228NLBM`) is unavailable from FRED, the ingestor automatically falls back to downloading daily gold prices from [Stooq](https://stooq.com) and resamples them to weekly values.


### PR DESCRIPTION
## Summary
- implement `_fetch_stooq_gold_price`
- fallback to Stooq when FRED gold series fails
- ensure ingestion uses this logic
- document new behaviour
- add tests for Stooq fetching and fallback

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf50b06e08331afb4d3cda5d723b7