### PR TITLE
Fix silent downcast warning

### DIFF
--- a/src/ingest.py
+++ b/src/ingest.py
@@ -214,6 +214,7 @@ async def ingest_weekly() -> pd.DataFrame:
     if "volume" in df.columns:
         df = df.drop(columns=["volume"])
     df = df.sort_index().ffill()
+    df = df.infer_objects(copy=False)
     df.index.name = "date"
     df_weekly = (
         df.resample("W-MON", label="left", closed="left").last().reset_index()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
+import warnings
 
 import httpx
 from src import ingest
@@ -141,7 +142,11 @@ async def test_ingest_weekly_fred_failure(monkeypatch):
     monkeypatch.setattr(ingest, "_fetch_coinmetrics", fake_fetch_coinmetrics)
     monkeypatch.setattr(ingest, "_fetch_fred_series", fake_fetch_fred_series)
 
-    df = await ingest.ingest_weekly()
+    with pd.option_context("future.no_silent_downcasting", True):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("error")
+            df = await ingest.ingest_weekly()
+    assert len(w) == 0
     assert pd.isna(df.loc[0, "fed_liq"])
 
 


### PR DESCRIPTION
## Summary
- forward fill the dataframe and infer object dtypes
- test that ingest_weekly doesn't emit a FutureWarning when pandas silent
  downcast option is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf8fb844883318b1258c47703a82b