### PR TITLE
Handle invalid Stooq response

### DIFF
--- a/src/ingest.py
+++ b/src/ingest.py
@@ -122,6 +122,12 @@ async def _fetch_stooq_gold_price(client: httpx.AsyncClient) -> pd.DataFrame:
 
     df = pd.read_csv(io.StringIO(resp.text))
     df.columns = [c.lower() for c in df.columns]
+
+    if "date" not in df.columns or "close" not in df.columns:
+        logger.warning("Stooq CSV missing required columns")
+        empty_index = pd.DatetimeIndex([], tz="UTC")
+        return pd.DataFrame(columns=["gold_price"], index=empty_index)
+
     df.rename(columns={"close": "gold_price"}, inplace=True)
     df["date"] = pd.to_datetime(df["date"], utc=True)
     df = (

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -176,6 +176,25 @@ async def test_fetch_stooq_gold_price(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_stooq_gold_price_invalid(monkeypatch):
+    class FakeResponse:
+        def __init__(self, text):
+            self.text = text
+
+        def raise_for_status(self):
+            pass
+
+    class FakeClient:
+        async def get(self, url, timeout=30):
+            return FakeResponse("No data")
+
+    df = await ingest._fetch_stooq_gold_price(FakeClient())
+    assert list(df.columns) == ["gold_price"]
+    assert df.empty
+    assert df.index.tz == timezone.utc
+
+
+@pytest.mark.asyncio
 async def test_fred_fallback_to_stooq(monkeypatch):
     class FakeResponse:
         def raise_for_status(self):


### PR DESCRIPTION
## Summary
- validate Stooq response columns when fetching gold price
- warn and return empty dataframe if columns are missing
- test Stooq CSV with invalid content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bfda4c24c8331a9d640fe8fd8aadd