### PR TITLE
Switch gold price fallback to Yahoo Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ export FRED_API_KEY="your_fred_key"
 
 When a requested series cannot be retrieved (for example if the key is missing or the API returns an error), the script continues and the affected column will be filled with `NA` values.
 
-If the gold price series (`GOLDAMGBD228NLBM`) is unavailable from FRED, the ingestor automatically falls back to downloading daily gold prices from [Stooq](https://stooq.com) and resamples them to weekly values.
+If the gold price series (`GOLDAMGBD228NLBM`) is unavailable from FRED, the ingestor automatically falls back to downloading daily gold prices from Yahoo Finance and resamples them to weekly values.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg2-binary
 python-dotenv
 pytest
 pytest-asyncio
+yfinance>=0.2


### PR DESCRIPTION
## Summary
- add `yfinance` dependency
- fetch gold prices from Yahoo Finance if FRED data fails
- adjust README to mention Yahoo fallback
- rewrite tests for new Yahoo helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bfeca32d08331b1640d878c0e45bd