### PR TITLE
Handle missing Close column for Yahoo gold data

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -156,6 +156,7 @@ async def test_fetch_yahoo_gold(monkeypatch):
         {"Adj Close": [4, 5]},
         index=[pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")],
     )
+    df_raw.index.name = "Date"
 
     def fake_download(*args, **kwargs):
         return df_raw
@@ -171,7 +172,9 @@ async def test_fetch_yahoo_gold(monkeypatch):
 @pytest.mark.asyncio
 async def test_fetch_yahoo_gold_invalid(monkeypatch):
     def fake_download(*args, **kwargs):
-        return pd.DataFrame({"Close": [1]}, index=[pd.Timestamp("2024-01-01")])
+        df = pd.DataFrame({"Open": [1]}, index=[pd.Timestamp("2024-01-01")])
+        df.index.name = "Date"
+        return df
 
     monkeypatch.setattr(ingest.yf, "download", fake_download)
 

--- a/tests/test_yahoo_close_column.py
+++ b/tests/test_yahoo_close_column.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import pytest
+from datetime import timezone
+
+from src import ingest
+
+
+@pytest.mark.asyncio
+async def test_yahoo_close_column(monkeypatch):
+    df_raw = pd.DataFrame({"Close": [7, 8]}, index=[pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")])
+    df_raw.index.name = "Date"
+
+    def fake_download(*args, **kwargs):
+        return df_raw
+
+    monkeypatch.setattr(ingest.yf, "download", fake_download)
+
+    df = await ingest._fetch_yahoo_gold()
+    assert list(df.columns) == ["gold_price"]
+    assert df.index.tz == timezone.utc
+    assert df.iloc[0]["gold_price"] == 8


### PR DESCRIPTION
## Summary
- make `_fetch_yahoo_gold()` robust when `Adj Close` column is missing
- ensure fallback works by looking for `Close` column
- add regression test for `Close`-only dataframes
- adjust invalid Yahoo test for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c010731788331b660a73c901d2d5c