### PR TITLE
Use named template for execute_values

### DIFF
--- a/src/ingest.py
+++ b/src/ingest.py
@@ -256,10 +256,12 @@ async def ingest_weekly() -> pd.DataFrame:
         columns = ",".join(SCHEMA_COLUMNS)
         update = ",".join([f"{c} = EXCLUDED.{c}" for c in SCHEMA_COLUMNS[1:]])
         with conn, conn.cursor() as cur:
+            template = "(" + ",".join(f"%({col})s" for col in SCHEMA_COLUMNS) + ")"
             psycopg2.extras.execute_values(
                 cur,
                 f"INSERT INTO btc_weekly ({columns}) VALUES %s ON CONFLICT (week_start) DO UPDATE SET {update}",
                 [row.iloc[0].to_dict()],
+                template=template,
             )
         conn.close()
 


### PR DESCRIPTION
## Summary
- use a named-template string when ingesting weekly data into Postgres

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cfc0fc4008331b9a7a5046bc21960