### PR TITLE
Add automatic DB table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ export DATABASE_URL="postgresql://user:password@localhost:5432/bitcoin"
 If this variable is not set, the ingestion script will skip the database upsert
 step.
 
+The ingestion utility will create the `btc_weekly` table automatically if it is
+missing. When the TimescaleDB extension is available, the table is converted
+into a hypertable, but it also works with a plain PostgreSQL database.
+
 ## FRED API access
 Some economic series fetched from FRED may not be available via the simple CSV endpoint used by the ingestor.
 For those series you can provide a personal FRED API key through the `FRED_API_KEY` environment variable:


### PR DESCRIPTION
## Summary
- create `btc_weekly` table on demand and try to convert it to a hypertable
- call the setup function from `ingest_weekly`
- document the behaviour in the README
- test new table creation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d007c9ffc83319bcc0805b621f112