### PR TITLE
Fix database init race condition

### DIFF
--- a/tests/test_db_init.py
+++ b/tests/test_db_init.py
@@ -1,0 +1,40 @@
+import pytest
+from src import ingest
+
+
+def test_init_db_commit_order(monkeypatch):
+    calls = []
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, sql):
+            calls.append(("execute", sql))
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+        def commit(self):
+            calls.append(("commit", None))
+
+    def fake_execute_values(cur, sql, argslist, template=None):
+        calls.append(("execute", sql))
+
+    monkeypatch.setattr(ingest.psycopg2.extras, "execute_values", fake_execute_values)
+
+    row = {col: 1 for col in ingest.SCHEMA_COLUMNS}
+    ingest._init_db(FakeConn(), row)
+
+    executed_sql = [c[1] for c in calls if c[0] == "execute"]
+    create_idx = next(i for i, s in enumerate(executed_sql) if "CREATE TABLE IF NOT EXISTS btc_weekly" in s)
+    insert_idx = next(i for i, s in enumerate(executed_sql) if "INSERT INTO btc_weekly" in s)
+    assert create_idx < insert_idx
+
+    commit_indices = [i for i, c in enumerate(calls) if c[0] == "commit"]
+    insert_call_index = calls.index(("execute", executed_sql[insert_idx]))
+    assert any(idx < insert_call_index for idx in commit_indices)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -253,6 +253,9 @@ async def test_ingest_weekly_db_upsert(monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             pass
 
+        def commit(self):
+            pass
+
         def close(self):
             pass
 
@@ -305,6 +308,9 @@ async def test_table_setup_called(monkeypatch):
             return self
 
         def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def commit(self):
             pass
 
         def close(self):
@@ -360,6 +366,9 @@ def test_create_table_if_missing(monkeypatch):
 
         def cursor(self):
             return FakeCursor()
+
+        def commit(self):
+            pass
 
     ingest._create_table_if_missing(FakeConn())
 


### PR DESCRIPTION
## Summary
- ensure `btc_weekly` table creation is committed before hypertable or insert
- add `_init_db` helper for table creation and upsert
- record informative log message after table creation
- update ingest logic to use `_init_db`
- extend tests for new commit behavior and add new `test_db_init` suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0e7e7dcc8331bc69da5f9c0b7112