### PR TITLE
Implement feature builder module

### DIFF
--- a/src/features.py
+++ b/src/features.py
@@ -1,0 +1,121 @@
+import logging
+import os
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+import psycopg2
+
+logger = logging.getLogger(__name__)
+
+
+FEATURE_COLS: List[str] = [
+    "Momentum_4w",
+    "Momentum_12w",
+    "Momentum_26w",
+    "Realised_Price_Delta",
+    "nupl",
+    "fed_liq_z",
+    "ecb_liq_z",
+    "dxy_z",
+    "ust10_z",
+    "gold_price_z",
+    "spx_index_z",
+    "Combined_Liq",
+    "Liq_Change",
+    "DXY_Invert",
+    "Target",
+]
+
+
+def _load_btc_weekly() -> pd.DataFrame:
+    """Load btc_weekly data from the database or CSV fallback."""
+    db_url = os.getenv("DATABASE_URL")
+    if db_url:
+        try:
+            conn = psycopg2.connect(db_url)
+            query = (
+                "SELECT week_start, close_usd, realised_price, nupl, "
+                "fed_liq, ecb_liq, dxy, ust10, gold_price, spx_index "
+                "FROM btc_weekly ORDER BY week_start"
+            )
+            df = pd.read_sql(query, conn)
+            conn.close()
+            df["week_start"] = pd.to_datetime(df["week_start"], utc=True)
+            df = df.sort_values("week_start").reset_index(drop=True)
+            return df
+        except Exception as exc:  # pragma: no cover - fallback path
+            logger.warning("Failed to read database: %s", exc)
+    try:
+        df = pd.read_csv("data/btc_weekly_latest.csv")
+        df["week_start"] = pd.to_datetime(df["week_start"], utc=True)
+        df = df.sort_values("week_start").reset_index(drop=True)
+        logger.info("Loaded %s rows from CSV fallback", len(df))
+        return df
+    except FileNotFoundError:
+        logger.error("No data source found for btc_weekly")
+        return pd.DataFrame(columns=[
+            "week_start",
+            "close_usd",
+            "realised_price",
+            "nupl",
+            "fed_liq",
+            "ecb_liq",
+            "dxy",
+            "ust10",
+            "gold_price",
+            "spx_index",
+        ])
+
+
+def build_features(lookback_weeks: int = 260) -> pd.DataFrame:
+    """Build feature dataframe from btc_weekly raw data."""
+    df = _load_btc_weekly()
+    if df.empty:
+        return df
+
+    df = df.set_index("week_start")
+    df = df.sort_index()
+
+    df["Momentum_4w"] = df["close_usd"].pct_change(4)
+    df["Momentum_12w"] = df["close_usd"].pct_change(12)
+    df["Momentum_26w"] = df["close_usd"].pct_change(26)
+
+    df["Realised_Price_Delta"] = df["close_usd"] / df["realised_price"] - 1
+
+    for col in ["fed_liq", "ecb_liq", "dxy", "ust10", "gold_price", "spx_index"]:
+        rolling = df[col].rolling(window=52)
+        df[f"{col}_z"] = (df[col] - rolling.mean()) / rolling.std()
+
+    df["Combined_Liq"] = df["fed_liq"] + df["ecb_liq"]
+    df["Liq_Change"] = df["Combined_Liq"].pct_change(52)
+    df["DXY_Invert"] = 1 / df["dxy"]
+
+    df["Target"] = df["close_usd"].shift(-4) / df["close_usd"] - 1
+
+    df = df.tail(lookback_weeks + 52 + 4)  # ensure lookback window
+
+    df = df.dropna(subset=FEATURE_COLS)
+
+    df = df.tail(lookback_weeks)
+
+    df = df.sort_index()
+    return df
+
+
+def save_latest_features(df: pd.DataFrame, path: str = "artifacts/features_latest.parquet") -> None:
+    """Save the most recent feature row to a parquet file."""
+    if df.empty:
+        logger.warning("No features to save")
+        return
+    latest = df.tail(1)
+    dest = Path(path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    latest.to_parquet(dest)
+    logger.info("Saved latest features to %s", dest)
+
+
+if __name__ == "__main__":
+    features = build_features()
+    save_latest_features(features)
+    print(features.tail(3))

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src import features
+
+
+def _sample_df(rows: int = 60) -> pd.DataFrame:
+    dates = pd.date_range("2022-01-03", periods=rows, freq="W-MON", tz="UTC")
+    data = {
+        "week_start": dates,
+        "close_usd": np.linspace(100, 200, rows),
+        "realised_price": np.linspace(90, 180, rows),
+        "nupl": np.linspace(0, 1, rows),
+        "fed_liq": np.arange(rows, dtype=float),
+        "ecb_liq": np.arange(rows, dtype=float),
+        "dxy": np.linspace(90, 100, rows),
+        "ust10": np.linspace(2, 3, rows),
+        "gold_price": np.linspace(1500, 1600, rows),
+        "spx_index": np.linspace(3000, 3100, rows),
+    }
+    return pd.DataFrame(data)
+
+
+def _patch_csv(monkeypatch: Any, df: pd.DataFrame) -> None:
+    def fake_read_csv(path: str) -> pd.DataFrame:
+        assert path == "data/btc_weekly_latest.csv"
+        return df
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+
+
+def test_feature_columns_present(monkeypatch):
+    df = _sample_df()
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _patch_csv(monkeypatch, df)
+
+    feat = features.build_features(lookback_weeks=52)
+    for col in features.FEATURE_COLS:
+        assert col in feat.columns
+
+
+def test_target_shift(monkeypatch):
+    df = _sample_df(60)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _patch_csv(monkeypatch, df)
+
+    feat = features.build_features(lookback_weeks=52)
+    if feat.empty:
+        pytest.skip("no data produced")
+    first_idx = feat.index[0]
+
+    orig = df.set_index("week_start")
+    target_series = orig["close_usd"].shift(-4) / orig["close_usd"] - 1
+    expected = target_series.loc[first_idx]
+    assert pytest.approx(feat.loc[first_idx, "Target"], rel=1e-9) == expected
+
+
+def test_no_nans(monkeypatch):
+    df = _sample_df(60)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    _patch_csv(monkeypatch, df)
+
+    feat = features.build_features(lookback_weeks=52)
+    assert feat[features.FEATURE_COLS].isna().sum().sum() == 0


### PR DESCRIPTION
## Summary
- add `src/features.py` implementing weekly feature engineering
- support CSV fallback when no DB available and CLI entry point
- store last computed feature row in parquet
- test feature generation logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1e629f38833185db698c00f9f033