### PR TITLE
Add backfill capability

### DIFF
--- a/src/backfill.py
+++ b/src/backfill.py
@@ -1,0 +1,38 @@
+import argparse
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+
+from . import ingest
+
+logger = logging.getLogger(__name__)
+
+
+def backfill(start_date: datetime, end_date: datetime | None = None) -> None:
+    """Backfill btc_weekly data from ``start_date`` up to ``end_date``."""
+    end_date = end_date or datetime.now(timezone.utc)
+    anchor = (start_date - timedelta(days=start_date.weekday())).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    end_limit = (end_date - timedelta(days=end_date.weekday())).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    while anchor <= end_limit:
+        logger.info("Ingesting week starting %s", anchor.date())
+        asyncio.run(ingest.ingest_weekly(week_anchor=anchor))
+        anchor += timedelta(days=7)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backfill btc_weekly history")
+    parser.add_argument(
+        "--years", type=int, default=15, help="Number of years to backfill"
+    )
+    args = parser.parse_args()
+
+    start = datetime.now(timezone.utc) - timedelta(days=args.years * 365)
+    backfill(start)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,22 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src import backfill, ingest
+
+
+def test_backfill_runs(monkeypatch):
+    calls = []
+
+    async def fake_ingest(week_anchor=None):
+        calls.append(week_anchor)
+
+    monkeypatch.setattr(ingest, "ingest_weekly", fake_ingest)
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = start + timedelta(days=14)
+    backfill.backfill(start, end)
+
+    expected = [start + timedelta(days=7 * i) for i in range(3)]
+    assert calls == expected

--- a/tests/test_ffill.py
+++ b/tests/test_ffill.py
@@ -11,11 +11,11 @@ async def test_forward_fill(monkeypatch):
     week_start = (now - timedelta(days=now.weekday())).replace(hour=0, minute=0, second=0, microsecond=0)
     prev_week = week_start - timedelta(days=7)
 
-    async def fake_fetch_coingecko(client):
+    async def fake_fetch_coingecko(client, *args, **kwargs):
         ts = int(now.timestamp() * 1000)
         return {"prices": [[ts, 10]], "total_volumes": [[ts, 1]]}
 
-    async def fake_fetch_coinmetrics(client):
+    async def fake_fetch_coinmetrics(client, *args, **kwargs):
         df = pd.DataFrame({"realised_price": [1], "nupl": [0]}, index=[week_start])
         return df
 
@@ -34,11 +34,11 @@ async def test_forward_fill(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_week_start_present(monkeypatch):
-    async def fake_fetch_coingecko(client):
+    async def fake_fetch_coingecko(client, *args, **kwargs):
         ts = int(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
         return {"prices": [[ts, 10]], "total_volumes": [[ts, 1]]}
 
-    async def fake_fetch_coinmetrics(client):
+    async def fake_fetch_coinmetrics(client, *args, **kwargs):
         week = pd.Timestamp("2024-01-01", tz="UTC")
         df = pd.DataFrame({"realised_price": [1], "nupl": [1]}, index=[week])
         return df

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -26,13 +26,13 @@ def test_coin_gecko_to_weekly():
 async def test_schema_columns(monkeypatch):
     week_start = pd.Timestamp("2024-01-01", tz="UTC")
 
-    async def fake_fetch_coingecko(client):
+    async def fake_fetch_coingecko(client, *args, **kwargs):
         return {
             "prices": [[int(week_start.timestamp() * 1000), 10]],
             "total_volumes": [[int(week_start.timestamp() * 1000), 1]],
         }
 
-    async def fake_fetch_coinmetrics(client):
+    async def fake_fetch_coinmetrics(client, *args, **kwargs):
         df = pd.DataFrame({
             "realised_price": [1],
             "nupl": [1],
@@ -127,11 +127,11 @@ async def test_fetch_fred_series_error(monkeypatch):
 async def test_ingest_weekly_fred_failure(monkeypatch):
     week_start = pd.Timestamp("2024-01-01", tz="UTC")
 
-    async def fake_fetch_coingecko(client):
+    async def fake_fetch_coingecko(client, *args, **kwargs):
         ts = int(week_start.timestamp() * 1000)
         return {"prices": [[ts, 10]], "total_volumes": [[ts, 1]]}
 
-    async def fake_fetch_coinmetrics(client):
+    async def fake_fetch_coinmetrics(client, *args, **kwargs):
         df = pd.DataFrame({"realised_price": [1], "nupl": [0]}, index=[week_start])
         return df
 
@@ -214,11 +214,11 @@ async def test_ingest_weekly_db_upsert(monkeypatch):
 
     week_start = pd.Timestamp("2024-01-01", tz="UTC")
 
-    async def fake_fetch_coingecko(client):
+    async def fake_fetch_coingecko(client, *args, **kwargs):
         ts = int(week_start.timestamp() * 1000)
         return {"prices": [[ts, 10]], "total_volumes": [[ts, 1]]}
 
-    async def fake_fetch_coinmetrics(client):
+    async def fake_fetch_coinmetrics(client, *args, **kwargs):
         df = pd.DataFrame({"realised_price": [1], "nupl": [1]}, index=[week_start])
         return df
 
@@ -282,10 +282,10 @@ async def test_ingest_weekly_db_upsert(monkeypatch):
 async def test_table_setup_called(monkeypatch):
     calls = []
 
-    async def fake_fetch_coingecko(client):
+    async def fake_fetch_coingecko(client, *args, **kwargs):
         return {"prices": [[0, 1]], "total_volumes": [[0, 1]]}
 
-    async def fake_fetch_coinmetrics(client):
+    async def fake_fetch_coinmetrics(client, *args, **kwargs):
         df = pd.DataFrame({"realised_price": [1], "nupl": [1]}, index=[pd.Timestamp.utcnow()])
         return df
 


### PR DESCRIPTION
## Summary
- extend `ingest_weekly` with an optional `week_anchor` to ingest historical weeks
- allow `_fetch_coingecko` and `_fetch_coinmetrics` to fetch specific date ranges
- add a `backfill` script for populating `btc_weekly` history
- update tests for new call signatures and cover backfill

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d26e854948331a4fb308258a773ea