### PR TITLE
Improve ingest retry handling

### DIFF
--- a/src/backfill.py
+++ b/src/backfill.py
@@ -20,6 +20,7 @@ def backfill(start_date: datetime, end_date: datetime | None = None) -> None:
     while anchor <= end_limit:
         logger.info("Ingesting week starting %s", anchor.date())
         asyncio.run(ingest.ingest_weekly(week_anchor=anchor))
+        asyncio.run(asyncio.sleep(0.5))
         anchor += timedelta(days=7)
 
 


### PR DESCRIPTION
## Summary
- add `_fetch_with_retry` wrapper for HTTP errors
- fall back to Yahoo Finance when CoinGecko returns 401/429
- add `_fetch_yahoo_btc` helper
- sleep between backfill iterations
- test retry and fallback behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d29832dc4833187c62a2a0e3c6d87