### PR TITLE
Use Yahoo Finance for backfill

### DIFF
--- a/src/ingest.py
+++ b/src/ingest.py
@@ -54,24 +54,21 @@ async def _fetch_coingecko(
     start: datetime | None = None,
     end: datetime | None = None,
 ) -> pd.DataFrame:
-    """Fetch Bitcoin prices from Coingecko with fallback to Yahoo."""
+    """Fetch Bitcoin prices.
 
-    if start and (datetime.now(timezone.utc) - start).days > 365:
-        logger.info("Date %s older than 365 days - using Yahoo Finance", start.date())
-        return await _fetch_yahoo_btc(start=start, end=end)
+    When ``start`` and ``end`` are provided the data is pulled from Yahoo
+    Finance instead of CoinGecko. This avoids hitting the range endpoint and
+    keeps the return schema consistent with the live path.
+    """
 
     if start or end:
         if not (start and end):
             raise ValueError("Both start and end must be provided for range fetch")
-        url = COINGECKO_URL + "/range"
-        params = {
-            "vs_currency": "usd",
-            "from": int(start.timestamp()),
-            "to": int(end.timestamp()),
-        }
-    else:
-        url = COINGECKO_URL
-        params = {"vs_currency": "usd", "days": days, "interval": "daily"}
+        logger.info("Fetching BTC price from Yahoo Finance for %s", start.date())
+        return await _fetch_yahoo_btc(start=start, end=end)
+
+    url = COINGECKO_URL
+    params = {"vs_currency": "usd", "days": days, "interval": "daily"}
 
     headers = {}
     api_key = os.getenv("COINGECKO_API_KEY")

--- a/tests/test_price_fallback.py
+++ b/tests/test_price_fallback.py
@@ -37,26 +37,41 @@ class FakeClient:
 
 
 @pytest.mark.asyncio
-async def test_fallback_to_yahoo_on_401(monkeypatch):
+async def test_historical_anchor_uses_yahoo(monkeypatch):
+    """_fetch_coingecko should use Yahoo Finance when a range is requested."""
     week = datetime.now(timezone.utc) - timedelta(days=400)
-    payload = {"prices": [[int(week.timestamp() * 1000), 10]], "total_volumes": [[int(week.timestamp() * 1000), 1]]}
-    client = FakeClient([FakeResp(401), FakeResp(401), FakeResp(401)])
+    yahoo_calls = 0
 
     async def fake_yahoo(*args, **kwargs):
+        nonlocal yahoo_calls
+        yahoo_calls += 1
         return pd.DataFrame({"close_usd": [5], "volume": [pd.NA]}, index=[week])
 
-    monkeypatch.setattr(ingest.httpx, "AsyncClient", lambda *a, **k: client)
+    httpx_called = False
+
+    class NoCallClient(FakeClient):
+        async def get(self, *a, **k):
+            nonlocal httpx_called
+            httpx_called = True
+            return await super().get(*a, **k)
+
+    client = NoCallClient([FakeResp(200)])
     monkeypatch.setattr(ingest, "_fetch_yahoo_btc", fake_yahoo)
 
     df = await ingest._fetch_coingecko(client, start=week, end=week + timedelta(days=7))
-    assert not df.empty
-    assert pd.isna(df.iloc[0]["volume"])
+
+    assert yahoo_calls == 1
+    assert not httpx_called
+    assert list(df.columns) == ["close_usd", "volume"]
 
 
 @pytest.mark.asyncio
 async def test_header_added(monkeypatch):
     week = datetime.now(timezone.utc)
-    payload = {"prices": [[int(week.timestamp() * 1000), 10]], "total_volumes": [[int(week.timestamp() * 1000), 1]]}
+    payload = {
+        "prices": [[int(week.timestamp() * 1000), 10]],
+        "total_volumes": [[int(week.timestamp() * 1000), 1]],
+    }
     resp = FakeResp(200, payload)
 
     captured = {}
@@ -70,6 +85,6 @@ async def test_header_added(monkeypatch):
     monkeypatch.setenv("COINGECKO_API_KEY", "abc")
     monkeypatch.setattr(ingest.httpx, "AsyncClient", lambda *a, **k: client)
 
-    df = await ingest._fetch_coingecko(client, start=week, end=week + timedelta(days=7))
+    df = await ingest._fetch_coingecko(client)
     assert "x-cg-demo-api-key" in captured.get("headers", {})
     assert not df.empty


### PR DESCRIPTION
## Summary
- skip CoinGecko during back-fill and pull BTC price from Yahoo Finance instead
- drop auth header for historical price fetches
- update tests to expect Yahoo usage

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d46968dd88331a184bcfca49172c2