### PR TITLE
Remove FRED dependency and use Yahoo Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,8 @@ The ingestion utility will create the `btc_weekly` table automatically if it is
 missing. When the TimescaleDB extension is available, the table is converted
 into a hypertable, but it also works with a plain PostgreSQL database.
 
-## FRED API access
-Some economic series fetched from FRED may not be available via the simple CSV endpoint used by the ingestor.
-For those series you can provide a personal FRED API key through the `FRED_API_KEY` environment variable:
-
-```bash
-export FRED_API_KEY="your_fred_key"
-```
-
-When a requested series cannot be retrieved (for example if the key is missing or the API returns an error), the script continues and the affected column will be filled with `NA` values.
-
-Gold prices are sourced directly from Yahoo Finance using the GLD ETF ticker and resampled to weekly values.
+Gold prices and macroeconomic series are sourced from Yahoo Finance and
+resampled to weekly values.
 
 ## Coingecko API access
 Some endpoints on Coingecko now require an API key. If you encounter authorization errors, set the `COINGECKO_API_KEY` environment variable:

--- a/src/features.py
+++ b/src/features.py
@@ -15,14 +15,10 @@ FEATURE_COLS: List[str] = [
     "Momentum_26w",
     "Realised_Price_Delta",
     "nupl",
-    "fed_liq_z",
-    "ecb_liq_z",
     "dxy_z",
     "ust10_z",
     "gold_price_z",
     "spx_index_z",
-    "Combined_Liq",
-    "Liq_Change",
     "DXY_Invert",
     "Target",
 ]
@@ -36,7 +32,7 @@ def _load_btc_weekly() -> pd.DataFrame:
             conn = psycopg2.connect(db_url)
             query = (
                 "SELECT week_start, close_usd, realised_price, nupl, "
-                "fed_liq, ecb_liq, dxy, ust10, gold_price, spx_index "
+                "dxy, ust10, gold_price, spx_index "
                 "FROM btc_weekly ORDER BY week_start"
             )
             df = pd.read_sql(query, conn)
@@ -59,8 +55,6 @@ def _load_btc_weekly() -> pd.DataFrame:
             "close_usd",
             "realised_price",
             "nupl",
-            "fed_liq",
-            "ecb_liq",
             "dxy",
             "ust10",
             "gold_price",
@@ -83,12 +77,9 @@ def build_features(lookback_weeks: int = 260) -> pd.DataFrame:
 
     df["Realised_Price_Delta"] = df["close_usd"] / df["realised_price"] - 1
 
-    for col in ["fed_liq", "ecb_liq", "dxy", "ust10", "gold_price", "spx_index"]:
+    for col in ["dxy", "ust10", "gold_price", "spx_index"]:
         rolling = df[col].rolling(window=52)
         df[f"{col}_z"] = (df[col] - rolling.mean()) / rolling.std()
-
-    df["Combined_Liq"] = df["fed_liq"] + df["ecb_liq"]
-    df["Liq_Change"] = df["Combined_Liq"].pct_change(52)
     df["DXY_Invert"] = 1 / df["dxy"]
 
     df["Target"] = df["close_usd"].shift(-4) / df["close_usd"] - 1

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -22,8 +22,6 @@ SCHEMA_COLUMNS: List[str] = [
     "close_usd",
     "realised_price",
     "nupl",
-    "fed_liq",
-    "ecb_liq",
     "dxy",
     "ust10",
     "gold_price",
@@ -32,18 +30,6 @@ SCHEMA_COLUMNS: List[str] = [
 
 COINGECKO_URL = "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart"
 COINMETRICS_URL = "https://community-api.coinmetrics.io/v4/timeseries/asset-metrics"
-FRED_URL = "https://api.stlouisfed.org/fred/series/observations"
-FRED_API_KEY = os.getenv("FRED_API_KEY")
-
-
-# Mapping of FRED series IDs to dataframe column names
-FRED_COLUMN_MAP = {
-    "WALCL": "fed_liq",
-    "ECBASSETS": "ecb_liq",
-    "DTWEXBGS": "dxy",
-    "DGS10": "ust10",
-    "SP500": "spx_index",
-}
 
 
 async def _fetch_coingecko(
@@ -186,28 +172,27 @@ async def _fetch_coinmetrics(
     return df[["realised_price", "nupl"]]
 
 
-async def _fetch_yahoo_gold() -> pd.DataFrame:
-    """Fetch GLD (gold ETF) prices from Yahoo Finance and resample to weekly."""
+async def _fetch_yahoo_series(ticker: str, column_name: str) -> pd.DataFrame:
+    """Fetch a ticker from Yahoo Finance and resample to weekly."""
     start = pd.Timestamp.utcnow().normalize().to_pydatetime().replace(tzinfo=None)
     try:
         raw = await asyncio.to_thread(
             yf.download,
-            "GLD",
+            ticker,
             period="1mo",
             interval="1d",
             auto_adjust=False,
         )
     except YFPricesMissingError:
-        logger.warning("Failed to fetch gold price from Yahoo Finance")
+        logger.warning("Failed to fetch %s from Yahoo Finance", ticker)
         return pd.DataFrame(
-            {"gold_price": [pd.NA]}, index=[pd.Timestamp(start, tz="UTC")]
+            {column_name: [pd.NA]}, index=[pd.Timestamp(start, tz="UTC")]
         )
     except Exception:
-        logger.warning("Failed to fetch gold price from Yahoo Finance")
+        logger.warning("Failed to fetch %s from Yahoo Finance", ticker)
         empty_index = pd.DatetimeIndex([], tz="UTC")
-        return pd.DataFrame(columns=["gold_price"], index=empty_index)
+        return pd.DataFrame(columns=[column_name], index=empty_index)
 
-    # Flatten MultiIndex columns from yfinance (e.g. ('Adj Close', 'GLD'))
     if isinstance(raw.columns, pd.MultiIndex):
         raw.columns = raw.columns.droplevel(1)
 
@@ -217,21 +202,19 @@ async def _fetch_yahoo_gold() -> pd.DataFrame:
     elif "Close" in raw.columns:
         price_col = "Close"
     if price_col is None:
-        logger.warning("Yahoo Finance data missing Close column")
+        logger.warning("Yahoo Finance data missing Close column for %s", ticker)
         empty_index = pd.DatetimeIndex([], tz="UTC")
-        return pd.DataFrame(columns=["gold_price"], index=empty_index)
+        return pd.DataFrame(columns=[column_name], index=empty_index)
 
     if raw.empty:
         return pd.DataFrame(
-            {"gold_price": [pd.NA]}, index=[pd.Timestamp(start, tz="UTC")]
+            {column_name: [pd.NA]}, index=[pd.Timestamp(start, tz="UTC")]
         )
 
     series = raw[price_col]
-    # ``yfinance`` may return a DataFrame when multiple columns share the
-    # selected name. In that case pick the first column to obtain a Series.
     if isinstance(series, pd.DataFrame):
         series = series.iloc[:, 0]
-    series.name = "gold_price"
+    series.name = column_name
     series.index = pd.to_datetime(series.index, utc=True)
     df = (
         series
@@ -239,13 +222,18 @@ async def _fetch_yahoo_gold() -> pd.DataFrame:
         .last()
         .to_frame()
     )
-    logger.info("Fetched %s rows for Yahoo gold price", len(df))
+    logger.info("Fetched %s rows for Yahoo %s", len(df), ticker)
     if df.empty:
         stub = pd.DataFrame(
-            {"gold_price": [pd.NA]}, index=[pd.Timestamp(start, tz="UTC")]
+            {column_name: [pd.NA]}, index=[pd.Timestamp(start, tz="UTC")]
         )
         return stub
-    return df[["gold_price"]]
+    return df[[column_name]]
+
+
+async def _fetch_yahoo_gold() -> pd.DataFrame:
+    """Fetch GLD (gold ETF) prices from Yahoo Finance and resample to weekly."""
+    return await _fetch_yahoo_series("GLD", "gold_price")
 
 
 async def _fetch_yahoo_btc(
@@ -315,33 +303,6 @@ async def _fetch_yahoo_btc(
     return df[["close_usd", "volume"]]
 
 
-async def _fetch_fred_series(client: httpx.AsyncClient, series_id: str) -> pd.DataFrame:
-    params = {"series_id": series_id, "file_type": "json"}
-    if FRED_API_KEY:
-        params["api_key"] = FRED_API_KEY
-    column_name = FRED_COLUMN_MAP.get(series_id, series_id.lower())
-    resp = await client.get(FRED_URL, params=params, timeout=30)
-    resp.raise_for_status()
-    payload = resp.json()
-    observations = payload.get("observations", [])
-    df = pd.DataFrame(observations)
-    if df.empty or "date" not in df.columns:
-        logger.warning("Unexpected FRED payload for %s", series_id)
-        empty_index = pd.DatetimeIndex([], tz="UTC")
-        return pd.DataFrame(columns=[column_name], index=empty_index)
-    df["date"] = pd.to_datetime(df["date"], utc=True)
-    df[column_name] = pd.to_numeric(df.get("value", pd.NA), errors="coerce")
-    df = df.set_index("date").resample("W-MON", label="left", closed="left").last()
-    logger.info("Fetched %s rows for %s", len(df), series_id)
-    if df.empty:
-        stub = pd.DataFrame(
-            {column_name: [pd.NA]},
-            index=[pd.Timestamp.utcnow().normalize()],
-        )
-        return stub
-    return df[[column_name]]
-
-
 async def _fetch_with_retry(func, *, name: str, columns: List[str], fallback=None):
     """Retry wrapper for network fetchers."""
     delay = 1
@@ -387,8 +348,6 @@ def _create_table_if_missing(conn: psycopg2.extensions.connection) -> None:
         close_usd DOUBLE PRECISION,
         realised_price DOUBLE PRECISION,
         nupl DOUBLE PRECISION,
-        fed_liq DOUBLE PRECISION,
-        ecb_liq DOUBLE PRECISION,
         dxy DOUBLE PRECISION,
         ust10 DOUBLE PRECISION,
         gold_price DOUBLE PRECISION,
@@ -476,52 +435,18 @@ async def ingest_weekly(week_anchor: datetime | None = None) -> pd.DataFrame:
                     columns=["realised_price", "nupl"],
                 )
             )
-        fed_liq_task = asyncio.create_task(
-            _fetch_with_retry(
-                lambda: _fetch_fred_series(client, "WALCL"),
-                name="fred",
-                columns=["fed_liq"],
-            )
-        )
-        ecb_liq_task = asyncio.create_task(
-            _fetch_with_retry(
-                lambda: _fetch_fred_series(client, "ECBASSETS"),
-                name="fred",
-                columns=["ecb_liq"],
-            )
-        )
-        dxy_task = asyncio.create_task(
-            _fetch_with_retry(
-                lambda: _fetch_fred_series(client, "DTWEXBGS"),
-                name="fred",
-                columns=["dxy"],
-            )
-        )
-        ust10_task = asyncio.create_task(
-            _fetch_with_retry(
-                lambda: _fetch_fred_series(client, "DGS10"),
-                name="fred",
-                columns=["ust10"],
-            )
-        )
+        dxy_task = asyncio.create_task(_fetch_yahoo_series("DX-Y.NYB", "dxy"))
+        ust10_task = asyncio.create_task(_fetch_yahoo_series("^TNX", "ust10"))
         gold_task = asyncio.create_task(_fetch_gold())
-        sp500_task = asyncio.create_task(
-            _fetch_with_retry(
-                lambda: _fetch_fred_series(client, "SP500"),
-                name="fred",
-                columns=["spx_index"],
-            )
-        )
+        sp500_task = asyncio.create_task(_fetch_yahoo_series("^GSPC", "spx_index"))
 
         cg_data = await cg_task
         cm_data = await cm_task
-        fed_liq = await fed_liq_task
-        ecb_liq = await ecb_liq_task
         dxy = await dxy_task
         ust10 = await ust10_task
         gold = await gold_task
         sp500 = await sp500_task
-    frames = [cg_data, cm_data, fed_liq, ecb_liq, dxy, ust10, gold, sp500]
+    frames = [cg_data, cm_data, dxy, ust10, gold, sp500]
     df = pd.concat(frames, axis=1)
     if "volume" in df.columns:
         df = df.drop(columns=["volume"])

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -14,8 +14,6 @@ def _sample_df(rows: int = 60) -> pd.DataFrame:
         "close_usd": np.linspace(100, 200, rows),
         "realised_price": np.linspace(90, 180, rows),
         "nupl": np.linspace(0, 1, rows),
-        "fed_liq": np.arange(rows, dtype=float),
-        "ecb_liq": np.arange(rows, dtype=float),
         "dxy": np.linspace(90, 100, rows),
         "ust10": np.linspace(2, 3, rows),
         "gold_price": np.linspace(1500, 1600, rows),

--- a/tests/test_ffill.py
+++ b/tests/test_ffill.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pandas as pd
 import pytest
 from datetime import datetime, timezone, timedelta
 
@@ -18,14 +19,13 @@ async def test_forward_fill(monkeypatch):
         df = pd.DataFrame({"realised_price": [1], "nupl": [0]}, index=[week_start])
         return df
 
-    async def fake_fetch_fred_series(client, series_id):
-        col = ingest.FRED_COLUMN_MAP.get(series_id, series_id.lower())
-        df = pd.DataFrame({col: [5]}, index=[prev_week])
+    async def fake_fetch_yahoo_series(ticker, column_name):
+        df = pd.DataFrame({column_name: [5]}, index=[prev_week])
         return df
 
     monkeypatch.setattr(ingest, "_fetch_coingecko", fake_fetch_coingecko)
     monkeypatch.setattr(ingest, "_fetch_coinmetrics", fake_fetch_coinmetrics)
-    monkeypatch.setattr(ingest, "_fetch_fred_series", fake_fetch_fred_series)
+    monkeypatch.setattr(ingest, "_fetch_yahoo_series", fake_fetch_yahoo_series)
 
     df = await ingest.ingest_weekly()
     assert df["gold_price"].isna().sum() == 0
@@ -42,15 +42,14 @@ async def test_week_start_present(monkeypatch):
         df = pd.DataFrame({"realised_price": [1], "nupl": [1]}, index=[week])
         return df
 
-    async def fake_fetch_fred_series(client, series_id):
+    async def fake_fetch_yahoo_series(ticker, column_name):
         week = pd.Timestamp("2024-01-01", tz="UTC")
-        col = ingest.FRED_COLUMN_MAP.get(series_id, series_id.lower())
-        df = pd.DataFrame({col: [1]}, index=[week])
+        df = pd.DataFrame({column_name: [1]}, index=[week])
         return df
 
     monkeypatch.setattr(ingest, "_fetch_coingecko", fake_fetch_coingecko)
     monkeypatch.setattr(ingest, "_fetch_coinmetrics", fake_fetch_coinmetrics)
-    monkeypatch.setattr(ingest, "_fetch_fred_series", fake_fetch_fred_series)
+    monkeypatch.setattr(ingest, "_fetch_yahoo_series", fake_fetch_yahoo_series)
 
     df = await ingest.ingest_weekly()
     assert df["week_start"].notna().all()


### PR DESCRIPTION
## Summary
- drop FRED constants and series logic in favor of Yahoo Finance tickers
- adjust feature generation to new macro inputs
- clean up tests and documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fbe2a277483319ee91c91336af2e6